### PR TITLE
Set custom timeout for insecure connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ client.setHeader("X-Test-Header1: one");
 client.setContentType("application/json");
 ```
 
+### setTimeout(unsigned int timeoutMilliseconds)
+
+Available for non-secure connections as currently WiFiClientSecure doesn't implement `setTimeout`.
+
+```
+client.setTimeout(1000)
+```
+
 ## Full Example
 
 I test every way of calling the library (against a public heroku app)[https://github.com/csquared/arduino-http-test].

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ String response = "";
 int statusCode = client.del("/", &response);
 ```
 
+## Request Configuration
+
+### setHeader(const char* header)
+
+```
+client.setHeader("X-Test-Header1: one");
+```
+
+### setContentType(const char* contentTypeValue)
+
+```
+client.setContentType("application/json");
+```
+
 ## Full Example
 
 I test every way of calling the library (against a public heroku app)[https://github.com/csquared/arduino-http-test].

--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -13,6 +13,7 @@ RestClient::RestClient(const char* _host){
   port = 80;
   num_headers = 0;
   contentType = "application/x-www-form-urlencoded";	// default
+  timeout = 5000;
   use_https = false;
   fingerprint = "";
 }
@@ -22,6 +23,7 @@ RestClient::RestClient(const char* _host, int _port){
   port = _port;
   num_headers = 0;
   contentType = "application/x-www-form-urlencoded";	// default
+  timeout = 5000;
   use_https = false;
   fingerprint = "";
 }
@@ -110,6 +112,10 @@ void RestClient::setContentType(const char* contentTypeValue){
   contentType = contentTypeValue;
 }
 
+void RestClient::setTimeout(unsigned int timeoutMilliseconds) {
+    timeout = timeoutMilliseconds;
+}
+
 void RestClient::setSecureConnection(bool secureConn){
   use_https = secureConn;
 }
@@ -144,6 +150,8 @@ int RestClient::request(const char* method, const char* path,
 
   } else {
     //Normal connection
+    client.setTimeout(timeout);
+
     if(!client.connect(host, port)){
       HTTP_DEBUG_PRINT("HTTP Connection failed\n");
       return 0;

--- a/RestClient.h
+++ b/RestClient.h
@@ -18,6 +18,9 @@ class RestClient {
     void setHeader(const char*);
     // Set Content-Type Header
     void setContentType(const char*);
+    // Set Request timeout
+    void setTimeout(unsigned int);
+
 
     //Set to use a secure connection
     void setSecureConnection(bool secureConn);
@@ -61,4 +64,5 @@ class RestClient {
     bool use_https;
     const char* fingerprint;
 	const char* contentType;
+    unsigned int timeout;
 };


### PR DESCRIPTION
This PR allows users to set a custom timeout for REST requests. The WifiClient default is 5000 ms, but it exposes a method (`setTimeout`) to change this value. I've forwarded this method to be available to RestClient users.

As far as I can tell WifiClientSecure doesn't yet expose a setTimeout method, so custom timeout periods are not possible with secure connections. This might be possible in the future.